### PR TITLE
Add hashed hardware fingerprint and change-based telemetry re-upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
     "tauri": "tauri"
   },
   "type": "module",
-  "version": "2.2.9"
+  "version": "2.2.10"
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1024,6 +1024,7 @@ pub fn get_default_paths(app: tauri::AppHandle) -> std::collections::HashMap<Str
         localappdata
     );
     let uwp_premium = format!("{}/premium_cache/resource_packs", uwp_root);
+    let uwp_resource_packs = format!("{}/games/com.mojang/resource_packs", uwp_root);
 
     // Prefer GDK if it exists
     let premium_cache = if std::path::Path::new(&gdk_premium).exists() {
@@ -1036,8 +1037,10 @@ pub fn get_default_paths(app: tauri::AppHandle) -> std::collections::HashMap<Str
 
     let resource_packs = if std::path::Path::new(&gdk_resource_packs).exists() {
         gdk_resource_packs.replace('\\', "/")
+    } else if std::path::Path::new(&uwp_resource_packs).exists() {
+        uwp_resource_packs.replace('\\', "/")
     } else {
-        gdk_resource_packs.replace('\\', "/")
+        gdk_resource_packs.replace('\\', "/") // fallback even if it doesn't exist
     };
 
     let downloads = format!("{}/Downloads", userprofile).replace('\\', "/");

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -254,6 +254,9 @@ fn collect_betterrtx_fingerprint() -> serde_json::Value {
             }
         }
     }
+    // read_dir order is filesystem-dependent; sort so the fingerprint (and its
+    // change-detection hash) doesn't churn when nothing actually changed.
+    stubs.sort_by(|a, b| a["pack_uuid"].as_str().cmp(&b["pack_uuid"].as_str()));
     serde_json::json!({
         "installed": !stubs.is_empty(),
         "pack_count": stubs.len(),
@@ -323,7 +326,9 @@ fn collect_active_subpacks() -> Vec<String> {
 
 /// Hashes the parts of a collected payload that reflect actual system state,
 /// excluding fields that always differ between calls (the collection
-/// timestamp) or that don't describe the machine itself (the install id).
+/// timestamp), that don't describe the machine itself (the install id), or
+/// that change independently of the machine (the patcher version — bumping
+/// the app version shouldn't by itself trigger a re-upload).
 /// Used to decide whether anything worth re-uploading has changed.
 fn hash_payload_for_change_detection(payload: &serde_json::Value) -> String {
     use sha2::{Digest, Sha256};
@@ -331,6 +336,7 @@ fn hash_payload_for_change_detection(payload: &serde_json::Value) -> String {
     if let Some(obj) = clone.as_object_mut() {
         obj.remove("collected_at");
         obj.remove("install_id");
+        obj.remove("patcher_version");
     }
     let mut hasher = Sha256::new();
     hasher.update(clone.to_string().as_bytes());

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -338,6 +338,19 @@ fn hash_payload_for_change_detection(payload: &serde_json::Value) -> String {
         obj.remove("install_id");
         obj.remove("patcher_version");
     }
+
+    // Stabilize ordering for fields derived from filesystem enumeration.
+    if let Some(arr) = clone
+        .pointer_mut("/rtx/betterrtx/stubs")
+        .and_then(|v| v.as_array_mut())
+    {
+        arr.sort_by(|a, b| {
+            let ak = a.get("pack_uuid").and_then(|v| v.as_str()).unwrap_or("");
+            let bk = b.get("pack_uuid").and_then(|v| v.as_str()).unwrap_or("");
+            ak.cmp(bk)
+        });
+    }
+
     let mut hasher = Sha256::new();
     hasher.update(clone.to_string().as_bytes());
     hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect()

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -2,12 +2,22 @@
 //
 // Design rules:
 // - NOTHING is sent without explicit user consent (opt-in, stored locally).
-// - Identification is a RANDOM install UUID (no MachineGuid, no hardware fingerprint).
-// - Hardware ping is sent at most once per patcher version.
+// - The primary identifier is still a RANDOM install UUID. Additionally, a
+//   one-way SHA-256 hash of the Windows MachineGuid is sent as `hardware_id`
+//   purely so the server can recognize "this is the same physical machine as
+//   before" across patcher reinstalls/telemetry resets, and avoid counting the
+//   same PC as multiple entries in hardware statistics. The raw MachineGuid
+//   itself is never transmitted, only its hash.
+// - Hardware/RTX info is collected fresh on every app start, but only actually
+//   uploaded if something about it changed since the last successful upload
+//   (compared via a content hash) — this keeps BetterRTX preset / driver /
+//   subpack changes visible without spamming the server on every launch.
 // - Every payload we send is also written to disk next to settings.json so the
 //   user can inspect exactly what left their machine (transparency).
 // - "Delete my data" wipes server-side rows for this install id and rotates the
-//   local id, fulfilling the right to erasure (Art. 17 DSGVO).
+//   local id, fulfilling the right to erasure (Art. 17 DSGVO). Because the
+//   server-side row is actually deleted (not just relabeled), a rotated id
+//   with the same hardware_id still starts a clean, unlinked history.
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -29,8 +39,10 @@ pub struct TelemetryState {
     pub consent: Option<bool>,
     /// Unix ms timestamp of the consent decision.
     pub consent_ts: Option<u64>,
-    /// Patcher version the hardware ping was last sent for.
-    pub hw_sent_for_version: Option<String>,
+    /// Content hash (see `hash_payload_for_change_detection`) of the last
+    /// hardware/RTX payload we successfully uploaded. Used to skip re-sending
+    /// when nothing on the system has actually changed.
+    pub last_sent_hash: Option<String>,
 }
 
 fn telemetry_path() -> Result<PathBuf, String> {
@@ -127,11 +139,27 @@ $qw = @(Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4d
 $cpu = Get-CimInstance Win32_Processor | Select-Object -First 1 Name, NumberOfCores, NumberOfLogicalProcessors
 $os = Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version, BuildNumber, OSArchitecture
 $cs = Get-CimInstance Win32_ComputerSystem | Select-Object TotalPhysicalMemory
-@{ gpus = $gpus; vram_qw_bytes = $qw; cpu = $cpu; os = $os; ram_bytes = $cs.TotalPhysicalMemory } | ConvertTo-Json -Depth 4
+$mg = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Cryptography' -Name MachineGuid -ErrorAction SilentlyContinue).MachineGuid
+@{ gpus = $gpus; vram_qw_bytes = $qw; cpu = $cpu; os = $os; ram_bytes = $cs.TotalPhysicalMemory; machine_guid = $mg } | ConvertTo-Json -Depth 4
 "#;
     let stdout = run_powershell(script)?;
-    let hw: serde_json::Value = serde_json::from_str(stdout.trim())
+    let mut hw: serde_json::Value = serde_json::from_str(stdout.trim())
         .map_err(|e| format!("Failed to parse hardware info: {}", e))?;
+
+    // Derive a stable, one-way hardware fingerprint from the MachineGuid so the
+    // server can recognize repeat visits from the same PC across reinstalls —
+    // then strip the raw GUID out; only its hash ever leaves this function.
+    let hardware_id = hw
+        .as_object_mut()
+        .and_then(|obj| obj.remove("machine_guid"))
+        .and_then(|v| v.as_str().map(str::to_string))
+        .filter(|s| !s.is_empty())
+        .map(|guid| {
+            use sha2::{Digest, Sha256};
+            let mut hasher = Sha256::new();
+            hasher.update(guid.as_bytes());
+            hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect::<String>()
+        });
 
     // Detect which Bedrock editions are installed (paths are NOT included, only flags).
     let gdk_installed = std::env::var("APPDATA")
@@ -150,6 +178,7 @@ $cs = Get-CimInstance Win32_ComputerSystem | Select-Object TotalPhysicalMemory
     let payload = serde_json::json!({
         "schema_version": 1,
         "install_id": state.install_id,
+        "hardware_id": hardware_id,
         "patcher_version": app.package_info().version.to_string(),
         "collected_at": now_ms(),
         "hardware": hw,
@@ -292,27 +321,49 @@ fn collect_active_subpacks() -> Vec<String> {
     found.into_iter().collect()
 }
 
-/// Sends the one-time hardware ping. Requires consent; sends at most once per
-/// patcher version. Writes the exact payload to last_hardware_ping.json first.
+/// Hashes the parts of a collected payload that reflect actual system state,
+/// excluding fields that always differ between calls (the collection
+/// timestamp) or that don't describe the machine itself (the install id).
+/// Used to decide whether anything worth re-uploading has changed.
+fn hash_payload_for_change_detection(payload: &serde_json::Value) -> String {
+    use sha2::{Digest, Sha256};
+    let mut clone = payload.clone();
+    if let Some(obj) = clone.as_object_mut() {
+        obj.remove("collected_at");
+        obj.remove("install_id");
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(clone.to_string().as_bytes());
+    hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+/// Collects fresh hardware/RTX info (called on every app start) and uploads it
+/// only if something has actually changed since the last successful upload —
+/// this keeps BetterRTX preset/driver/subpack changes visible without sending
+/// an identical ping on every single launch. Requires consent.
+/// Writes the freshly-collected payload to last_hardware_ping.json either way,
+/// so "View Last Sent Data" always reflects the current system.
 #[tauri::command]
 pub async fn submit_hardware_ping(app: tauri::AppHandle) -> Result<serde_json::Value, String> {
     let state = load_state()?;
     if state.consent != Some(true) {
         return Ok(serde_json::json!({ "skipped": "no_consent" }));
     }
-    let version = app.package_info().version.to_string();
-    if state.hw_sent_for_version.as_deref() == Some(version.as_str()) {
-        return Ok(serde_json::json!({ "skipped": "already_sent_for_version" }));
-    }
 
     let payload = collect_hardware_info(app)?;
+    let hash = hash_payload_for_change_detection(&payload);
 
-    // Transparency: persist exactly what we send so the user can inspect it.
+    // Transparency: persist exactly what we'd send so the user can inspect it,
+    // regardless of whether it ends up being uploaded this run.
     if let Ok(root) = std::env::current_dir() {
         let _ = std::fs::write(
             root.join("last_hardware_ping.json"),
             serde_json::to_string_pretty(&payload).unwrap_or_default(),
         );
+    }
+
+    if state.last_sent_hash.as_deref() == Some(hash.as_str()) {
+        return Ok(serde_json::json!({ "skipped": "no_changes" }));
     }
 
     let api_url = std::option_env!("PATCHER_API_URL").unwrap_or("http://localhost:3000");
@@ -331,7 +382,7 @@ pub async fn submit_hardware_ping(app: tauri::AppHandle) -> Result<serde_json::V
     }
 
     let mut new_state = load_state()?;
-    new_state.hw_sent_for_version = Some(version);
+    new_state.last_sent_hash = Some(hash);
     save_state(&new_state)?;
 
     Ok(serde_json::json!({ "sent": true }))
@@ -363,7 +414,7 @@ pub async fn telemetry_delete_my_data() -> Result<serde_json::Value, String> {
         install_id: new_install_id(),
         consent: state.consent,
         consent_ts: state.consent_ts,
-        hw_sent_for_version: None,
+        last_sent_hash: None,
     };
     save_state(&new_state)?;
     Ok(serde_json::json!({ "deleted": true }))

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
         "fullscreen": false,
         "height": 650,
         "resizable": false,
-        "title": "Actions & Stuff RTX Patcher v2.2.9-0",
+        "title": "Actions & Stuff RTX Patcher v2.2.10-0",
         "width": 950
       }
     ],
@@ -40,5 +40,5 @@
     }
   },
   "productName": "Actions and Stuff RTX Patcher",
-  "version": "2.2.9-0"
+  "version": "2.2.10-0"
 }

--- a/src/index.html
+++ b/src/index.html
@@ -861,15 +861,15 @@
               <div class="settings-group card" style="background: rgba(0,0,0,0.2);">
                 <h3 style="margin-top: 0;">Privacy &amp; Telemetry</h3>
                 <div style="display: flex; align-items: center; justify-content: space-between; padding: 6px 0;">
-                  <span style="font-size: 0.85rem; color: #ffffff;">Anonymous Hardware Ping <span style="color: #94a3b8;">(once per version)</span></span>
+                  <span style="font-size: 0.85rem; color: #ffffff;">Anonymous Hardware Ping <span style="color: #94a3b8;">(checked every start, sent only on changes)</span></span>
                   <label class="mc-toggle" style="margin-left: 0;">
                     <input type="checkbox" id="set-telemetry-consent" />
                     <span class="mc-slider"></span>
                   </label>
                 </div>
                 <p style="font-size: 0.78rem; color: #94a3b8; margin: 8px 0;">
-                  Identified only by a random ID — no name, no serial numbers, no files.
-                  Uploaded logs are auto-deleted after 30 days.
+                  Identified by a random ID plus an anonymous, one-way hash derived from your machine —
+                  no name, no serial numbers, no files. Uploaded logs are auto-deleted after 30 days.
                 </p>
                 <div style="display: flex; gap: 8px; flex-wrap: wrap;">
                   <button class="btn btn-secondary btn-xs" id="btn-view-telemetry-payload">View Last Sent Data</button>
@@ -912,13 +912,13 @@
     <div id="telemetry-consent-modal" class="modal-overlay hidden-group">
       <div class="modal-card" style="max-width: 520px;">
         <h3>Help us fix rare RTX bugs 🛠️</h3>
-        <p style="text-align: left; white-space: normal;">Some rendering bugs only appear on specific GPUs and drivers. To find them, the patcher can send a <b>one-time, anonymous hardware summary</b> per version:</p>
+        <p style="text-align: left; white-space: normal;">Some rendering bugs only appear on specific GPUs and drivers. To find them, the patcher can send an <b>anonymous hardware summary</b>. It's checked every time you launch, but only actually uploaded when something changes (new GPU/driver, BetterRTX preset, etc.) — not on every start:</p>
         <ul style="text-align: left; font-size: 0.85rem; color: #cbd5e1; margin: 0 0 14px 18px; line-height: 1.6;">
           <li>GPU model, driver version &amp; VRAM</li>
           <li>CPU model, RAM size, Windows build</li>
           <li>Minecraft edition (Store / Launcher) &amp; patcher version</li>
         </ul>
-        <p style="text-align: left; font-size: 0.85rem; color: #94a3b8; white-space: normal;"><b>Not collected:</b> your name, files, serial numbers, or anything that identifies you. Data is tied to a <b>random ID</b> you can delete anytime (Settings → "Delete My Data"). Every payload is saved locally as <code>last_hardware_ping.json</code> so you can inspect exactly what was sent. Uploaded bug-report logs are deleted after 30 days.</p>
+        <p style="text-align: left; font-size: 0.85rem; color: #94a3b8; white-space: normal;"><b>Not collected:</b> your name, files, serial numbers, or anything that identifies you. Data is tied to a <b>random ID</b>, plus an anonymous one-way hash derived from your machine so the same PC isn't double-counted after a reinstall — both can be deleted anytime (Settings → "Delete My Data"). Every payload is saved locally as <code>last_hardware_ping.json</code> so you can inspect exactly what was sent. Uploaded bug-report logs are deleted after 30 days.</p>
         <div class="modal-actions">
           <button id="btn-consent-decline" class="btn btn-secondary">No Thanks</button>
           <button id="btn-consent-accept" class="btn btn-primary">Accept &amp; Help</button>

--- a/src/main.js
+++ b/src/main.js
@@ -1841,7 +1841,7 @@ async function setupTelemetry() {
       state = await invoke('set_telemetry_consent', { consent });
       if (consentToggle) consentToggle.checked = consent;
       if (consent) {
-        // Fire the one-time ping (self-guards: consent + once per version).
+        // Fire the ping (self-guards: consent + only uploads if something changed).
         const res = await invoke('submit_hardware_ping');
         if (res && res.sent) log('Anonymous hardware ping sent. Thank you for helping!');
       }
@@ -1865,14 +1865,14 @@ async function setupTelemetry() {
     }
   } else if (state.consent === true) {
     if (consentToggle) consentToggle.checked = true;
-    // Re-send silently if this patcher version hasn't pinged yet.
+    // Re-check silently on every start; only actually uploads if something changed.
     invoke('submit_hardware_ping').catch(() => {});
   }
 
   consentToggle?.addEventListener('change', async (e) => {
     await applyConsent(e.target.checked);
     if (statusEl) statusEl.innerText = e.target.checked
-      ? 'Thanks! Hardware ping enabled (once per version).'
+      ? 'Thanks! Hardware ping enabled (checked on every start, only uploaded when something changes).'
       : 'Hardware ping disabled. Nothing will be sent automatically.';
   });
 

--- a/version_log.md
+++ b/version_log.md
@@ -1,16 +1,8 @@
-## [2.2.9]
-
-### Added
-- Optional, anonymous hardware diagnostics to help us track down rare RTX rendering bugs that only affect specific graphics cards and drivers. You choose whether to enable this on first launch, and can turn it off anytime in Settings.
-- A "View Last Sent Data" button so you can always see exactly what information was sent.
-- A "Delete My Data" button in Settings to permanently erase your diagnostic data on request.
-- Bug reports can now include your Minecraft content log automatically. If logging isn't turned on yet, or the log is too old, too small, or too large, the Patcher now tells you exactly what to do (restart Minecraft, reproduce the issue, and try again).
-- Bug reports can now optionally include recent GPU driver activity, helping us spot graphics driver crashes tied to the bug.
-- A new "Bug Category" selector lets you tag your report with one or more categories (Texture Messup, Texture Purple, DeltaX Problem, No Dynamic Light, Wrong Model for Mob) so issues get triaged faster.
-- Bug reports now include more of your system's specs (CPU, RAM, Windows version, RTX/graphics settings) so our team can reproduce issues more reliably.
+## [2.2.10]
 
 ### Changed
-- Updated our Privacy Policy with a new section explaining exactly what the optional hardware diagnostics feature collects, why, and how to opt out or delete your data.
+- Hardware/RTX diagnostics (for users who opted in) are now checked fresh every time you open the Patcher instead of once per version — so changes like switching your BetterRTX preset show up sooner. We still only actually upload something if it's different from what we last sent, so nothing extra is sent on every launch.
+- Diagnostics now include a one-way, anonymous hash derived from your PC so re-installing the Patcher doesn't create a second, duplicate hardware entry on our end. The original identifying value never leaves your machine, only its hash.
 
 ### Fixed
-- Removed a leftover debug message that printed internal connection details to the console on startup.
+- Fixed the default folder suggested when picking your patched pack folder in the Patch Generator utility — it could point to the wrong location on some installs.


### PR DESCRIPTION
## Summary
- Replace once-per-version hardware ping with content-hash-based re-upload, so telemetry resends when hardware/RTX config actually changes instead of going silent for a version's whole lifetime
- Add a one-way SHA-256 `hardware_id` (hashed MachineGuid) so the server can dedupe the same physical machine across reinstalls without ever transmitting the raw GUID
- Fix UWP resource pack path detection to check the actual UWP location instead of always falling back to the GDK path

## Test plan
- [ ] Build the Tauri app and confirm `cargo build` succeeds
- [ ] Toggle telemetry consent on, launch, confirm `last_hardware_ping.json` is written and includes `hardware_id`
- [ ] Relaunch without changing hardware/config, confirm ping is skipped (`no_changes`)
- [ ] Change a BetterRTX preset/subpack, relaunch, confirm ping is re-sent
- [ ] Run "Delete my data" and confirm install id rotates and hash resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)