### PR TITLE
Fall back to AdapterRAM when accurate VRAM match fails

### DIFF
--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -182,11 +182,16 @@ $mg = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Cryptography' -Name Mach
                             .iter()
                             .find(|(desc, _)| desc.eq_ignore_ascii_case(name))
                             .map(|(_, vram)| *vram)
-                    });
+                    }).filter(|vram| *vram > 0);
+                    // Fall back to AdapterRAM (uint32, capped at 4GB) when the registry
+                    // lookup found nothing or matched to 0 — a capped-but-real VRAM
+                    // figure still orders correctly against an integrated GPU's much
+                    // smaller (or absent) allocation, whereas leaving VramBytes unset
+                    // would make the sort below treat this GPU as having 0 VRAM.
+                    let adapter_ram = gpu.get("AdapterRAM").and_then(|v| v.as_u64());
+                    let effective_vram = accurate_vram.or(adapter_ram).unwrap_or(0);
                     if let Some(map) = gpu.as_object_mut() {
-                        if let Some(vram) = accurate_vram {
-                            map.insert("VramBytes".to_string(), serde_json::json!(vram));
-                        }
+                        map.insert("VramBytes".to_string(), serde_json::json!(effective_vram));
                     }
                 }
 


### PR DESCRIPTION
## Summary
- This addresses the Copilot review comment from PR #33 (already merged): if the registry `DriverDesc` doesn't match `Win32_VideoController.Name`, `VramBytes` was left unset and the primary-GPU sort silently treated that GPU as 0 VRAM — undoing the fix for hybrid systems where the name match happens to fail.
- The commit implementing this fallback was pushed to the PR #33 branch, but the merge that landed on `main` only picked up the earlier commit, so this fix never actually made it in. Reapplying it here on its own branch.

## Test plan
- [ ] `cargo build` succeeds
- [ ] Confirm `git log --oneline -1 -- src-tauri/src/telemetry.rs` on main after merge shows this fallback present (`adapter_ram`/`effective_vram`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)