### PR TITLE
Add docs/WIKI.md: patch modes, Extract Brarchives, and full tools reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ Your A&S Copy ──→ xdelta3 + .vcdiff patch ──→ A&S Enhanced for RTX (
 
 ## 📖 Wiki / Full Feature Guide
 
-The **Patcher** tab covers the basics (Marketplace, Zip/McPack, and Custom Patch modes), but the app also ships a **Cleaner**, **RTX Settings** editor, a full **Utilities** menu (deterministic ZIP packer, archive extractor, the *Create Patch* tool used to build new `.vcdiff` patches, and a standalone *Extract Brarchives* tool for A&S releases that ship assets bundled in that custom container format), a **Bug Reporter**, and a **Release Builder** for maintainers.
+The **Patcher** tab covers the basics, but the app ships a lot more than just Marketplace auto-detect. The **[📖 Wiki](./docs/WIKI.md)** covers:
 
-For what each of those actually does, when you'd reach for **Extract Brarchives**, and how to build a **Custom Patch** from source, see the full **[📖 Wiki](./docs/WIKI.md)**.
+- 🔍 **How patching actually works** (the `encrypted.vcdiff` / `decrypted.vcdiff` split, and why both exist)
+- 🚀 **All three Patch Modes**: Marketplace (default), Zip / McPack, and Custom Patch, plus what **Advanced Mode** unlocks
+- 📦 **Extract Brarchives**: what the `__brarchive` container format actually is, and the real answer for when you need it (short version: almost never as a regular end user)
+- 🔧 **Building Custom Patches**: the full **Create Patch (VCDIFF)** workflow patch developers use to generate new `.vcdiff` releases, including every input folder and toggle
+- 🧰 **A tool-by-tool reference**: Cleaner, RTX Settings/`options.txt` editor, the Deterministic ZIP Packer, the Extract ZIP/MCPack utility, the Bug Reporter, and the maintainer-only Release Builder
+- ⚙️ **A full App Settings table** explaining what every toggle actually defaults to and controls
+- 🩹 **Troubleshooting** for the most common "something looks broken" and "patch didn't apply" cases
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 
 [![⬇ Beta](https://img.shields.io/badge/⬇_Beta-f58220?style=for-the-badge&logo=github&logoColor=white)](https://github.com/Felix-Chaos/Actions-and-Stuff-RTX-Patcher/releases/tag/V2.0.4b)
 
-[![📖 Tutorial](https://img.shields.io/badge/📖_Tutorial_&_Docs-0969da?style=for-the-badge)](./docs/TUTORIAL.md)
+[![📖 Wiki](https://img.shields.io/badge/📖_Wiki_&_Full_Guide-0969da?style=for-the-badge)](./docs/WIKI.md)
 
 </td>
 </tr>
@@ -103,6 +103,14 @@ Your A&S Copy ──→ xdelta3 + .vcdiff patch ──→ A&S Enhanced for RTX (
   <img src="./docs/showcase/showcase_image_2.jpg" width="32%" />
   <img src="./docs/showcase/showcase_image_4.png" width="32%" />
 </p>
+
+---
+
+## 📖 Wiki / Full Feature Guide
+
+The **Patcher** tab covers the basics (Marketplace, Zip/McPack, and Custom Patch modes), but the app also ships a **Cleaner**, **RTX Settings** editor, a full **Utilities** menu (deterministic ZIP packer, archive extractor, the *Create Patch* tool used to build new `.vcdiff` patches, and a standalone *Extract Brarchives* tool for A&S releases that ship assets bundled in that custom container format), a **Bug Reporter**, and a **Release Builder** for maintainers.
+
+For what each of those actually does, when you'd reach for **Extract Brarchives**, and how to build a **Custom Patch** from source, see the full **[📖 Wiki](./docs/WIKI.md)**.
 
 ---
 

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -5,7 +5,7 @@
 </td>
 <td>
 
-## 📖 A&S RTX Patcher — Wiki / Full Feature Guide
+## 📖 A&S RTX Patcher Wiki / Full Feature Guide
 
 *Every tab, every toggle, and when to actually use them*
 
@@ -17,7 +17,7 @@
 </tr>
 </table>
 
-This guide covers the current Tauri-based patcher (the app that ships as `Actions and Stuff RTX Patcher.exe`). If you just want the quick install steps, the [main README](../README.md) is enough — come here when you want to know what a specific button, toggle, or tab actually does.
+This guide covers the current Tauri-based patcher (the app that ships as `Actions and Stuff RTX Patcher.exe`). If you just want the quick install steps, the [main README](../README.md) is enough. Come here when you want to know what a specific button, toggle, or tab actually does.
 
 ---
 
@@ -28,14 +28,14 @@ This guide covers the current Tauri-based patcher (the app that ships as `Action
   - [Marketplace (default)](#-marketplace-default)
   - [Zip / McPack (Advanced Mode)](#-zip--mcpack-advanced-mode)
   - [Custom Patch (Advanced Mode)](#-custom-patch-advanced-mode)
-- [Extract Brarchives — what it is and when you need it](#-extract-brarchives--what-it-is-and-when-you-need-it)
+- [Extract Brarchives](#-extract-brarchives)
 - [Tools Reference](#-tools-reference)
   - [🧹 Cleaner](#-cleaner)
   - [🎛️ RTX Settings](#-rtx-settings)
   - [🛠️ Utilities](#-utilities)
     - [Deterministic ZIP Packer](#deterministic-zip-packer)
     - [Extract ZIP / MCPack](#extract-zip--mcpack)
-    - [Create Patch (VCDIFF)](#create-patch-vcdiff--custom-patches)
+    - [Create Patch (VCDIFF)](#create-patch-vcdiff)
     - [Extract Brarchives (standalone)](#extract-brarchives-standalone)
   - [💬 Support](#-support)
   - [📦 Release Builder (maintainers only)](#-release-builder-maintainers-only)
@@ -49,7 +49,7 @@ This guide covers the current Tauri-based patcher (the app that ships as `Action
 The patcher never redistributes any original Actions & Stuff asset. Instead it ships small binary diffs (`.vcdiff`, applied with [xdelta3](https://github.com/jmacd/xdelta)) that transform **your own legally-owned copy** into the RTX-enhanced version:
 
 ```
-Your A&S Copy ──→ xdelta3 + .vcdiff patch ──→ A&S Enhanced for RTX (.mcpack)
+Your A&S Copy → xdelta3 + .vcdiff patch → A&S Enhanced for RTX (.mcpack)
 ```
 
 Two `.vcdiff` files exist per patch version, because there are two possible starting points:
@@ -59,7 +59,7 @@ Two `.vcdiff` files exist per patch version, because there are two possible star
 | `encrypted.vcdiff` | Your raw, still-DRM-encrypted Marketplace cache | **Marketplace** mode |
 | `decrypted.vcdiff` | An already-decrypted/plain pack (a `.zip`/`.mcpack` you downloaded or extracted yourself) | **Zip / McPack** mode |
 
-Both patches reconstruct the exact same final pack — the tool just picks whichever one matches the format of the pack you're feeding it, so it never has to touch DRM-protected bytes it can't otherwise read.
+Both patches reconstruct the exact same final pack. The tool just picks whichever one matches the format of the pack you're feeding it, so it never has to touch DRM-protected bytes it can't otherwise read.
 
 ---
 
@@ -69,7 +69,7 @@ Pick a mode on the **Patcher** tab. The first is always available; the other two
 
 ### 🏪 Marketplace (default)
 
-Auto-detects your purchased Actions & Stuff pack directly from Minecraft's `premium_cache` (works for the Microsoft Store/UWP and GDK/Xbox app installs). This is the mode almost everyone should use — no manual file picking required.
+Auto-detects your purchased Actions & Stuff pack directly from Minecraft's `premium_cache` (works for the Microsoft Store/UWP and GDK/Xbox app installs). This is the mode almost everyone should use, no manual file picking required.
 
 1. Choose **Auto-Detect** or **Manual Select** for the target patch/pack version.
 2. Optionally leave **Delete older patched versions automatically** on to keep old installs from piling up.
@@ -81,27 +81,27 @@ For when you already have Actions & Stuff as a `.zip` or `.mcpack` file (e.g. do
 
 ### 🔧 Custom Patch (Advanced Mode)
 
-Lets you manually point at a specific **source** pack (folder or zip), **target** output path, and a specific `.vcdiff` **patch file** — bypassing the normal auto-detection entirely. Useful for testing a patch you (or a patch developer) just built with the [Create Patch tool](#create-patch-vcdiff--custom-patches), or for applying an older/specific patch version by hand.
+Lets you manually point at a specific **source** pack (folder or zip), **target** output path, and a specific `.vcdiff` **patch file**, bypassing the normal auto-detection entirely. Useful for testing a patch you (or a patch developer) just built with the [Create Patch tool](#create-patch-vcdiff), or for applying an older/specific patch version by hand.
 
 > [!TIP]
-> After any mode finishes, click **Install Pack** to copy the result straight into your Minecraft `resource_packs` folder — no manual extraction needed.
+> After any mode finishes, click **Install Pack** to copy the result straight into your Minecraft `resource_packs` folder, no manual extraction needed.
 
 ---
 
-## 📦 Extract Brarchives — what it is and when you need it
+## 📦 Extract Brarchives
 
-Some Actions & Stuff releases ship certain assets bundled inside a custom container format instead of as normal loose files: a `__brarchive` folder containing `*.brarchive` files, each of which is really several real files packed together with a small binary header.
+Some Actions & Stuff source material ships assets bundled inside a custom container format instead of as normal loose files: a `__brarchive` folder containing `*.brarchive` files, each of which is really several real files packed together with a small binary header.
 
-**When you need it:** if your source pack (Marketplace cache, `.zip`, or a folder you're using for [patch generation](#create-patch-vcdiff--custom-patches)) contains a `__brarchive` folder anywhere inside it. Without extracting them first, the patcher can't find the real files it needs to diff or patch — they're sitting inside the archive container, not at their expected path.
+**When you need it:** in practice, mainly when generating a new patch in the [Create Patch tool](#create-patch-vcdiff) with **Replace Unchanged** turned on. That option pulls substitute files straight from the raw, still-encrypted marketplace source, and if any of those live inside a `__brarchive` container, extraction has to run first or the tool won't find them at their expected path. **Replace Unchanged is off by default**, and should stay off unless verified in-game (see the warning under [Create Patch](#create-patch-vcdiff)), so for most patch-generation runs, and for virtually all regular end users applying an existing patch, you don't need to touch this toggle at all.
 
 **What it does:** recursively scans the target folder for `__brarchive` directories, unpacks every `.brarchive` file back into a normal file at the path it's named after (stripping the `.brarchive` suffix), then deletes the now-empty archive containers and any leftover `.brarchive` pointer files.
 
-**Where to turn it on:**
+**Where the toggle exists:**
 - **Patcher tab** → the "Extract Brarchives (Beta)" step runs automatically if **App Settings → Extract Brarchives automatically** is enabled.
 - **Create Patch tool** → its own "Extract Brarchives" toggle, applied to all three of your source/target folders before diffing.
-- **Utilities → Extract Brarchives** → a standalone version you can point at any folder directly, independent of the patching pipeline — handy if you just want to inspect what's inside a `__brarchive` folder without running a full patch.
+- **Utilities → Extract Brarchives** → a standalone version you can point at any folder directly, independent of the patching pipeline. Handy if you just want to inspect what's inside a `__brarchive` folder without running a full patch.
 
-If your pack doesn't have a `__brarchive` folder, leaving this off is harmless (it's a no-op) — but it's off by default because it's still marked **Beta**.
+If a folder doesn't have a `__brarchive` anywhere in it, running this is a harmless no-op, which is why it's still marked **Beta** and left off by default rather than something you need to actively avoid.
 
 ---
 
@@ -119,25 +119,25 @@ Reads and writes your Minecraft `options.txt` directly, so you can flip RTX-rele
 
 ### 🛠️ Utilities
 
-Standalone tools that don't run the full patch pipeline — useful for patch developers or troubleshooting.
+Standalone tools that don't run the full patch pipeline, useful for patch developers or troubleshooting.
 
 #### Deterministic ZIP Packer
 
-Compresses a folder into a `.zip`/`.mcpack` with fixed timestamps (Jan 1 1980) and no compression (stored). Two runs over identical input always produce a byte-identical archive — this determinism is what makes the xdelta diffs reproducible and small, so it's used internally everywhere the patcher creates a zip for diffing.
+Compresses a folder into a `.zip`/`.mcpack` with fixed timestamps (Jan 1 1980) and no compression (stored). Two runs over identical input always produce a byte-identical archive; this determinism is what makes the xdelta diffs reproducible and small, so it's used internally everywhere the patcher creates a zip for diffing.
 
 #### Extract ZIP / MCPack
 
-Extracts any `.zip` or `.mcpack` archive to a folder, automatically unwrapping a single redundant top-level folder if the archive has one (e.g. `MyPack-main/...` → just the pack contents).
+Extracts any `.zip` or `.mcpack` archive to a folder, automatically unwrapping a single redundant top-level folder if the archive has one (e.g. `MyPack-main/...` becomes just the pack contents).
 
-#### Create Patch (VCDIFF) — custom patches
+#### Create Patch (VCDIFF)
 
-This is how new patch versions actually get built. It's a maintainer/patch-developer tool, not something regular users need. It needs four inputs:
+This is how new patch versions actually get built, for custom/new patches. It's a maintainer/patch-developer tool, not something regular users need. It needs four inputs:
 
 | Input | What goes here |
 | :--- | :--- |
-| **1. Target Folder** | Your finished, modified "Actions & Stuff RTX" pack — the result you want end users to end up with |
+| **1. Target Folder** | Your finished, modified "Actions & Stuff RTX" pack, the result you want end users to end up with |
 | **2. Source Decrypted Folder** | A vanilla, already-decrypted baseline copy of the same Actions & Stuff version (no DRM) |
-| **3. Source Encrypted Folder** | The same vanilla version, but straight from `premium_cache` — still DRM-encrypted |
+| **3. Source Encrypted Folder** | The same vanilla version, but straight from `premium_cache`, still DRM-encrypted |
 | **Output Directory** | Where the finished `.vcdiff` files and `patch_config.json` get written |
 
 Plus **Pack Version** / **Patch Version** (used to name the output folder and populate `patch_config.json`), and three toggles:
@@ -145,18 +145,18 @@ Plus **Pack Version** / **Patch Version** (used to name the output folder and po
 | Toggle | Effect |
 | :--- | :--- |
 | **Inject Custom Manifest** | Writes the patcher's own `manifest.json` into both the decrypted baseline and the target folder before diffing, so the shipped pack always ends up with the correct custom pack identity |
-| **Extract Brarchives** | See [Extract Brarchives](#-extract-brarchives--what-it-is-and-when-you-need-it) above — runs it on all three input folders first |
-| **Replace Unchanged** | ⚠️ **Leave this off unless you've verified it in-game.** It substitutes any file that's byte-identical between the decrypted baseline and your target with the *raw DRM-encrypted* original, to shrink the diff. Files substituted this way ship as ciphertext with no guarantee Minecraft can still decrypt them once a custom manifest is in play — enabling it has previously produced patches where a bunch of assets silently failed to load. |
+| **Extract Brarchives** | See [Extract Brarchives](#-extract-brarchives) above, runs it on all three input folders first |
+| **Replace Unchanged** | ⚠️ **Off by default. Leave it off unless you've verified it in-game.** It substitutes any file that's byte-identical between the decrypted baseline and your target with the *raw DRM-encrypted* original, to shrink the diff. Files substituted this way ship as ciphertext with no guarantee Minecraft can still decrypt them once a custom manifest is in play; enabling it has previously produced patches where a bunch of assets silently failed to load. |
 
 Clicking **Create Patches** produces `encrypted.vcdiff`, `decrypted.vcdiff`, and a `patch_config.json` (pack/patch version + validation stats used by Marketplace auto-detection) in a new `Actions & Stuff for RTX <pack version> V<patch version>` folder under your chosen output directory.
 
 #### Extract Brarchives (standalone)
 
-Same brarchive extraction described [above](#-extract-brarchives--what-it-is-and-when-you-need-it), pointed at any folder you choose — independent of a patch run. Good for just inspecting/unpacking a `__brarchive` folder without doing anything else.
+Same brarchive extraction described [above](#-extract-brarchives), pointed at any folder you choose, independent of a patch run. Good for just inspecting/unpacking a `__brarchive` folder without doing anything else.
 
 ### 💬 Support
 
-Discord invite links (community + BetterRTX), and the **Bug Report** form. The bug reporter can optionally attach your application log, the pack you patched, a Minecraft content log (with usernames scrubbed from file paths), recent GPU driver events, and a hardware summary (GPU/CPU/RAM/BetterRTX preset) — all opt-in per checkbox, and all tied to a random install ID rather than anything personally identifying. See **App Settings → Privacy** for the underlying telemetry consent controls.
+Discord invite links (community + BetterRTX), and the **Bug Report** form. The bug reporter can optionally attach your application log, the pack you patched, a Minecraft content log (with usernames scrubbed from file paths), recent GPU driver events, and a hardware summary (GPU/CPU/RAM/BetterRTX preset), all opt-in per checkbox, and all tied to a random install ID rather than anything personally identifying. See **App Settings → Privacy** for the underlying telemetry consent controls.
 
 ### 📦 Release Builder (maintainers only)
 
@@ -171,7 +171,7 @@ Version bump + build automation for cutting a new patcher release: edit the app 
 | General | Opt-in to Beta Updates | Lets the in-app updater offer beta/alpha releases, not just stable |
 | Patcher Behaviors | Clean Old Patch Remnants | Runs the Cleaner scan automatically before every patch |
 | Patcher Behaviors | Extract Brarchives automatically | Runs brarchive extraction automatically during a normal patch run |
-| Patch Creator Defaults | Inject Custom Manifest / Extract Brarchives for Patch / Replace Unchanged JSONs | Default state of the matching toggles in the [Create Patch tool](#create-patch-vcdiff--custom-patches) |
+| Patch Creator Defaults | Inject Custom Manifest / Extract Brarchives for Patch / Replace Unchanged JSONs | Default state of the matching toggles in the [Create Patch tool](#create-patch-vcdiff) |
 | Bug Reporter Defaults | Include Application Log / Pack / Content Log / Driver Events / Hardware Info | Default state of the matching checkboxes on the bug report form |
 | Privacy | Telemetry consent, Delete My Data | Opt in/out of anonymous hardware pings, and erase your server-side data (rotates your local install ID) |
 
@@ -179,9 +179,9 @@ Version bump + build automation for cutting a new patcher release: edit the app 
 
 ## 🩹 Troubleshooting
 
-- **A texture/model/sound looks broken or purple after patching** — use the Bug Report form (Support tab) with the content log and hardware info included; this gives us the most actionable diagnostics.
-- **Nothing happens when I click Apply RTX Patch** — check the process log (Advanced Mode) for the actual error, and confirm you own a legitimate copy of Actions & Stuff in one of the supported formats.
-- **Just patched but Minecraft still shows the old pack** — make sure your resource pack load order matches the [README's setup section](../README.md), and run the Cleaner to remove stale duplicates.
+- **A texture/model/sound looks broken or purple after patching.** Use the Bug Report form (Support tab) with the content log and hardware info included; this gives us the most actionable diagnostics.
+- **Nothing happens when I click Apply RTX Patch.** Check the process log (Advanced Mode) for the actual error, and confirm you own a legitimate copy of Actions & Stuff in one of the supported formats.
+- **Just patched but Minecraft still shows the old pack.** Make sure your resource pack load order matches the [README's setup section](../README.md), and run the Cleaner to remove stale duplicates.
 - **Still stuck?** Ask in the [Discord](https://discord.gg/YrMMmN2kc7) or check the pinned [FAQ thread](https://discord.com/channels/691547840463241267/1360688874388455504/1376325634246049792).
 
 ---

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -1,0 +1,193 @@
+<table>
+<tr>
+<td width="180" align="center">
+<img width="140" alt="A&S RTX Patcher Logo" src="../assets/as_rtx_simple_logo_.png" />
+</td>
+<td>
+
+## 📖 A&S RTX Patcher — Wiki / Full Feature Guide
+
+*Every tab, every toggle, and when to actually use them*
+
+[![Back to Main README](https://img.shields.io/badge/←_Back_to_README-333?style=flat-square)](../README.md)
+[![Download Latest](https://img.shields.io/badge/⬇_Download-Latest_Release-2ea44f?style=flat-square&logo=github)](https://github.com/Felix-Chaos/Actions-and-Stuff-RTX-Patcher/releases/latest)
+[![Discord](https://img.shields.io/discord/1432653252171661364?logo=discord&style=flat-square&label=Discord)](https://discord.gg/YrMMmN2kc7)
+
+</td>
+</tr>
+</table>
+
+This guide covers the current Tauri-based patcher (the app that ships as `Actions and Stuff RTX Patcher.exe`). If you just want the quick install steps, the [main README](../README.md) is enough — come here when you want to know what a specific button, toggle, or tab actually does.
+
+---
+
+## Table of Contents
+
+- [How patching works](#-how-patching-works)
+- [Patch Modes](#-patch-modes)
+  - [Marketplace (default)](#-marketplace-default)
+  - [Zip / McPack (Advanced Mode)](#-zip--mcpack-advanced-mode)
+  - [Custom Patch (Advanced Mode)](#-custom-patch-advanced-mode)
+- [Extract Brarchives — what it is and when you need it](#-extract-brarchives--what-it-is-and-when-you-need-it)
+- [Tools Reference](#-tools-reference)
+  - [🧹 Cleaner](#-cleaner)
+  - [🎛️ RTX Settings](#-rtx-settings)
+  - [🛠️ Utilities](#-utilities)
+    - [Deterministic ZIP Packer](#deterministic-zip-packer)
+    - [Extract ZIP / MCPack](#extract-zip--mcpack)
+    - [Create Patch (VCDIFF)](#create-patch-vcdiff--custom-patches)
+    - [Extract Brarchives (standalone)](#extract-brarchives-standalone)
+  - [💬 Support](#-support)
+  - [📦 Release Builder (maintainers only)](#-release-builder-maintainers-only)
+  - [⚙️ App Settings](#-app-settings-reference)
+- [Troubleshooting](#-troubleshooting)
+
+---
+
+## 🔍 How Patching Works
+
+The patcher never redistributes any original Actions & Stuff asset. Instead it ships small binary diffs (`.vcdiff`, applied with [xdelta3](https://github.com/jmacd/xdelta)) that transform **your own legally-owned copy** into the RTX-enhanced version:
+
+```
+Your A&S Copy ──→ xdelta3 + .vcdiff patch ──→ A&S Enhanced for RTX (.mcpack)
+```
+
+Two `.vcdiff` files exist per patch version, because there are two possible starting points:
+
+| File | Diffed against | Used by |
+| :--- | :--- | :--- |
+| `encrypted.vcdiff` | Your raw, still-DRM-encrypted Marketplace cache | **Marketplace** mode |
+| `decrypted.vcdiff` | An already-decrypted/plain pack (a `.zip`/`.mcpack` you downloaded or extracted yourself) | **Zip / McPack** mode |
+
+Both patches reconstruct the exact same final pack — the tool just picks whichever one matches the format of the pack you're feeding it, so it never has to touch DRM-protected bytes it can't otherwise read.
+
+---
+
+## 🚀 Patch Modes
+
+Pick a mode on the **Patcher** tab. The first is always available; the other two require **Advanced Mode** (bottom-left toggle in the sidebar).
+
+### 🏪 Marketplace (default)
+
+Auto-detects your purchased Actions & Stuff pack directly from Minecraft's `premium_cache` (works for the Microsoft Store/UWP and GDK/Xbox app installs). This is the mode almost everyone should use — no manual file picking required.
+
+1. Choose **Auto-Detect** or **Manual Select** for the target patch/pack version.
+2. Optionally leave **Delete older patched versions automatically** on to keep old installs from piling up.
+3. Click **Apply RTX Patch**.
+
+### 📂 Zip / McPack (Advanced Mode)
+
+For when you already have Actions & Stuff as a `.zip` or `.mcpack` file (e.g. downloaded rather than pulled from the Marketplace cache). The patcher extracts it, strips Mojang's licensing metadata (`contents.json`, `signatures.json`, etc.), injects its own manifest, and applies `decrypted.vcdiff`.
+
+### 🔧 Custom Patch (Advanced Mode)
+
+Lets you manually point at a specific **source** pack (folder or zip), **target** output path, and a specific `.vcdiff` **patch file** — bypassing the normal auto-detection entirely. Useful for testing a patch you (or a patch developer) just built with the [Create Patch tool](#create-patch-vcdiff--custom-patches), or for applying an older/specific patch version by hand.
+
+> [!TIP]
+> After any mode finishes, click **Install Pack** to copy the result straight into your Minecraft `resource_packs` folder — no manual extraction needed.
+
+---
+
+## 📦 Extract Brarchives — what it is and when you need it
+
+Some Actions & Stuff releases ship certain assets bundled inside a custom container format instead of as normal loose files: a `__brarchive` folder containing `*.brarchive` files, each of which is really several real files packed together with a small binary header.
+
+**When you need it:** if your source pack (Marketplace cache, `.zip`, or a folder you're using for [patch generation](#create-patch-vcdiff--custom-patches)) contains a `__brarchive` folder anywhere inside it. Without extracting them first, the patcher can't find the real files it needs to diff or patch — they're sitting inside the archive container, not at their expected path.
+
+**What it does:** recursively scans the target folder for `__brarchive` directories, unpacks every `.brarchive` file back into a normal file at the path it's named after (stripping the `.brarchive` suffix), then deletes the now-empty archive containers and any leftover `.brarchive` pointer files.
+
+**Where to turn it on:**
+- **Patcher tab** → the "Extract Brarchives (Beta)" step runs automatically if **App Settings → Extract Brarchives automatically** is enabled.
+- **Create Patch tool** → its own "Extract Brarchives" toggle, applied to all three of your source/target folders before diffing.
+- **Utilities → Extract Brarchives** → a standalone version you can point at any folder directly, independent of the patching pipeline — handy if you just want to inspect what's inside a `__brarchive` folder without running a full patch.
+
+If your pack doesn't have a `__brarchive` folder, leaving this off is harmless (it's a no-op) — but it's off by default because it's still marked **Beta**.
+
+---
+
+## 🧰 Tools Reference
+
+Everything below lives behind the sidebar tabs. **Advanced Mode** (bottom-left toggle) is required to see the **Utilities** menu and a few of the Patcher-tab controls.
+
+### 🧹 Cleaner
+
+Scans every detected Minecraft install (Microsoft Store/UWP, GDK/Xbox app, and per-world `resource_packs`/`development_resource_packs` folders) for leftover Actions & Stuff pack directories from previous patches, and lets you delete the ones you select. Use this if you've patched several times and want to reclaim disk space, or before re-patching to avoid stale duplicate packs showing up in-game.
+
+### 🎛️ RTX Settings
+
+Reads and writes your Minecraft `options.txt` directly, so you can flip RTX-relevant graphics settings (`graphics_mode`, `graphics_api`, ray tracing/deferred view distance, upscaling mode & percentage, etc.) without hunting through Minecraft's in-game menus. **Set Best Settings** applies the recommended RTX configuration in one click; **Apply Settings** saves whatever you've edited manually. Pick which `options.txt` profile to target first if you have more than one Minecraft install/user profile.
+
+### 🛠️ Utilities
+
+Standalone tools that don't run the full patch pipeline — useful for patch developers or troubleshooting.
+
+#### Deterministic ZIP Packer
+
+Compresses a folder into a `.zip`/`.mcpack` with fixed timestamps (Jan 1 1980) and no compression (stored). Two runs over identical input always produce a byte-identical archive — this determinism is what makes the xdelta diffs reproducible and small, so it's used internally everywhere the patcher creates a zip for diffing.
+
+#### Extract ZIP / MCPack
+
+Extracts any `.zip` or `.mcpack` archive to a folder, automatically unwrapping a single redundant top-level folder if the archive has one (e.g. `MyPack-main/...` → just the pack contents).
+
+#### Create Patch (VCDIFF) — custom patches
+
+This is how new patch versions actually get built. It's a maintainer/patch-developer tool, not something regular users need. It needs four inputs:
+
+| Input | What goes here |
+| :--- | :--- |
+| **1. Target Folder** | Your finished, modified "Actions & Stuff RTX" pack — the result you want end users to end up with |
+| **2. Source Decrypted Folder** | A vanilla, already-decrypted baseline copy of the same Actions & Stuff version (no DRM) |
+| **3. Source Encrypted Folder** | The same vanilla version, but straight from `premium_cache` — still DRM-encrypted |
+| **Output Directory** | Where the finished `.vcdiff` files and `patch_config.json` get written |
+
+Plus **Pack Version** / **Patch Version** (used to name the output folder and populate `patch_config.json`), and three toggles:
+
+| Toggle | Effect |
+| :--- | :--- |
+| **Inject Custom Manifest** | Writes the patcher's own `manifest.json` into both the decrypted baseline and the target folder before diffing, so the shipped pack always ends up with the correct custom pack identity |
+| **Extract Brarchives** | See [Extract Brarchives](#-extract-brarchives--what-it-is-and-when-you-need-it) above — runs it on all three input folders first |
+| **Replace Unchanged** | ⚠️ **Leave this off unless you've verified it in-game.** It substitutes any file that's byte-identical between the decrypted baseline and your target with the *raw DRM-encrypted* original, to shrink the diff. Files substituted this way ship as ciphertext with no guarantee Minecraft can still decrypt them once a custom manifest is in play — enabling it has previously produced patches where a bunch of assets silently failed to load. |
+
+Clicking **Create Patches** produces `encrypted.vcdiff`, `decrypted.vcdiff`, and a `patch_config.json` (pack/patch version + validation stats used by Marketplace auto-detection) in a new `Actions & Stuff for RTX <pack version> V<patch version>` folder under your chosen output directory.
+
+#### Extract Brarchives (standalone)
+
+Same brarchive extraction described [above](#-extract-brarchives--what-it-is-and-when-you-need-it), pointed at any folder you choose — independent of a patch run. Good for just inspecting/unpacking a `__brarchive` folder without doing anything else.
+
+### 💬 Support
+
+Discord invite links (community + BetterRTX), and the **Bug Report** form. The bug reporter can optionally attach your application log, the pack you patched, a Minecraft content log (with usernames scrubbed from file paths), recent GPU driver events, and a hardware summary (GPU/CPU/RAM/BetterRTX preset) — all opt-in per checkbox, and all tied to a random install ID rather than anything personally identifying. See **App Settings → Privacy** for the underlying telemetry consent controls.
+
+### 📦 Release Builder (maintainers only)
+
+Version bump + build automation for cutting a new patcher release: edit the app version, build MSI/NSIS installers and/or a portable `.exe`, and sort the resulting artifacts into a `Releases/vX.Y.Z` folder with the updater manifest signature injected automatically. Not relevant unless you're publishing a new patcher build.
+
+### ⚙️ App Settings Reference
+
+| Group | Setting | Effect |
+| :--- | :--- | :--- |
+| General | Default Patcher Mode | Which patch mode is pre-selected on launch |
+| General | Enable Advanced Mode UI | Reveals Zip/Custom patch modes, the Utilities tab, and other advanced controls |
+| General | Opt-in to Beta Updates | Lets the in-app updater offer beta/alpha releases, not just stable |
+| Patcher Behaviors | Clean Old Patch Remnants | Runs the Cleaner scan automatically before every patch |
+| Patcher Behaviors | Extract Brarchives automatically | Runs brarchive extraction automatically during a normal patch run |
+| Patch Creator Defaults | Inject Custom Manifest / Extract Brarchives for Patch / Replace Unchanged JSONs | Default state of the matching toggles in the [Create Patch tool](#create-patch-vcdiff--custom-patches) |
+| Bug Reporter Defaults | Include Application Log / Pack / Content Log / Driver Events / Hardware Info | Default state of the matching checkboxes on the bug report form |
+| Privacy | Telemetry consent, Delete My Data | Opt in/out of anonymous hardware pings, and erase your server-side data (rotates your local install ID) |
+
+---
+
+## 🩹 Troubleshooting
+
+- **A texture/model/sound looks broken or purple after patching** — use the Bug Report form (Support tab) with the content log and hardware info included; this gives us the most actionable diagnostics.
+- **Nothing happens when I click Apply RTX Patch** — check the process log (Advanced Mode) for the actual error, and confirm you own a legitimate copy of Actions & Stuff in one of the supported formats.
+- **Just patched but Minecraft still shows the old pack** — make sure your resource pack load order matches the [README's setup section](../README.md), and run the Cleaner to remove stale duplicates.
+- **Still stuck?** Ask in the [Discord](https://discord.gg/YrMMmN2kc7) or check the pinned [FAQ thread](https://discord.com/channels/691547840463241267/1360688874388455504/1376325634246049792).
+
+---
+
+<div align="center">
+
+[![Back to Main README](https://img.shields.io/badge/←_Back_to_README-333?style=for-the-badge)](../README.md)
+
+</div>


### PR DESCRIPTION
## Summary

The README only ever documented the happy-path Marketplace flow. The app actually ships a full **Utilities** menu (deterministic ZIP packer, archive extractor, the **Create Patch** tool used to build new `.vcdiff` patches, and a standalone **Extract Brarchives** tool), plus a **Cleaner**, an **RTX Settings**/`options.txt` editor, a **Bug Reporter**, and a **Release Builder** for maintainers — none of that was written down anywhere for the current Tauri app.

### What's new

Added **`docs/WIKI.md`** covering:
- **How patching works** — why there are two `.vcdiff` files (`encrypted.vcdiff` vs `decrypted.vcdiff`) and what each is diffed against
- **Patch Modes** — Marketplace / Zip-McPack / Custom Patch, and when to reach for each
- **Extract Brarchives** — what the `__brarchive` container format actually is and when you need to unpack it, referenced from all three places it shows up (Patcher tab auto-run, the Create Patch tool, and the standalone Utilities entry)
- **Full tools reference** — Cleaner, RTX Settings, all four Utilities entries (including a walkthrough of the Create Patch tool's four folder inputs and its three toggles, with an explicit warning on **Replace Unchanged** consistent with the fix in #38), Support/Bug Reporter, Release Builder, and an App Settings reference table
- A short troubleshooting section

`README.md` gets a short teaser section pointing at the wiki instead of duplicating all of this, and the "Getting Started" quick-link badge now points at the wiki.

### Note on existing docs

`docs/TUTORIAL.md` and `docs/A_and_S_RTX_Patcher_Guide.md` both predate the Tauri rewrite — they describe the old Python/CustomTkinter version (`python main.py`, PyInstaller, `build.bat`, a completely different UI). I left them untouched since rewriting/removing those is a separate, larger call for the maintainer to make, but flagging it here since the README's old "Tutorial" badge was pointing new users at what's now a misleading doc — hence swapping that badge to the new wiki rather than leaving both.

## Test plan

- [x] Verified all relative links (`./docs/WIKI.md`, `../README.md`) resolve to real files
- [x] Checked every in-page anchor link in the wiki's table of contents against the actual rendered header text/slug rules, and fixed three that had a stray invisible variation-selector character baked into the anchor (RTX Settings, Utilities, App Settings Reference)
- [ ] Maintainer: decide whether `docs/TUTORIAL.md` / `docs/A_and_S_RTX_Patcher_Guide.md` should be updated, merged into the wiki, or removed now that they describe a different app entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)