### PR TITLE
Add 2.2.11 changelog entry

### DIFF
--- a/version_log.md
+++ b/version_log.md
@@ -1,3 +1,16 @@
+## [2.2.11]
+
+### Security
+- Enabled a strict content security policy for the app window (previously disabled), restricted the "open link" command to http(s) URLs only, and fixed a path-traversal edge case when unpacking `.brarchive` files.
+
+### Fixed
+- Turned off the Create Patch tool's "Replace Unchanged" option by default. It could ship patches where some assets stayed DRM-encrypted with no way for Minecraft to decrypt them, causing textures/models/sounds to silently fail to load. It's now clearly labeled as experimental if you re-enable it.
+- Settings and diagnostics files (`settings.json`, `telemetry.json`) now save to your Windows user profile instead of next to the app, so they're no longer shared or overwritten between different installs.
+
+### Added
+- Added a full Wiki guide (`docs/WIKI.md`) covering every tab and tool, including when you actually need Extract Brarchives and how the Create Patch workflow works.
+- Dependabot now actually watches for dependency updates across npm, Cargo, and GitHub Actions (its config was previously misconfigured and silently doing nothing).
+
 ## [2.2.10]
 
 ### Changed


### PR DESCRIPTION
## Summary

Adds a `## [2.2.11]` entry to `version_log.md` summarizing the work from the currently open PRs:

- **Security**: CSP hardening, `open_url` scheme restriction, `.brarchive` path-traversal fix (#36)
- **Fixed**: Replace Unchanged DRM/loading fix, now off by default (#37); per-user settings/telemetry storage (#38)
- **Added**: Wiki guide (#39), working Dependabot config (#36)

Written in the same short, user-facing style as the existing 2.2.10 entry. This only touches `version_log.md`; it doesn't bump the actual app version in `tauri.conf.json`/`package.json`/`updater.json` since that's handled by the in-app Release Builder tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)