### PR TITLE
Open diagnostics folder instead of dumping JSON in a giant modal

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub fn run() {
             save_settings,
             get_telemetry_state,
             set_telemetry_consent,
+            open_diagnostics_folder,
             collect_hardware_info,
             submit_hardware_ping,
             telemetry_delete_my_data,

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -102,6 +102,15 @@ pub fn set_telemetry_consent(app: tauri::AppHandle, consent: bool) -> Result<Tel
     Ok(state)
 }
 
+/// Opens the per-user app-data folder (settings.json, telemetry.json,
+/// last_hardware_ping.json) directly in Explorer, so the user can inspect
+/// the actual files rather than a giant JSON dump in an in-app modal.
+#[tauri::command]
+pub fn open_diagnostics_folder(app: tauri::AppHandle) -> Result<(), String> {
+    let dir = crate::utils::user_data_dir(&app)?;
+    crate::commands::open_in_explorer(dir.to_string_lossy().to_string())
+}
+
 // ---------------------------------------------------------------------------
 // PowerShell helper
 // ---------------------------------------------------------------------------

--- a/src/index.html
+++ b/src/index.html
@@ -878,7 +878,7 @@
                   no name, no serial numbers, no files. Uploaded logs are auto-deleted after 30 days.
                 </p>
                 <div style="display: flex; gap: 8px; flex-wrap: wrap;">
-                  <button class="btn btn-secondary btn-xs" id="btn-view-telemetry-payload">View Last Sent Data</button>
+                  <button class="btn btn-secondary btn-xs" id="btn-view-telemetry-payload">Open Diagnostics Folder</button>
                   <button class="btn btn-secondary btn-xs" id="btn-delete-telemetry-data" style="color: #f87171;">Delete My Data</button>
                 </div>
                 <p id="telemetry-settings-status" style="margin-top: 8px; font-size: 0.8rem; color: #94a3b8;"></p>

--- a/src/main.js
+++ b/src/main.js
@@ -1878,10 +1878,9 @@ async function setupTelemetry() {
 
   document.getElementById('btn-view-telemetry-payload')?.addEventListener('click', async () => {
     try {
-      const payload = await invoke('collect_hardware_info');
-      showModal(JSON.stringify(payload, null, 2), { title: 'Exactly this data would be sent' });
+      await invoke('open_diagnostics_folder');
     } catch (e) {
-      showModal(`Failed to collect hardware info: ${e}`, { title: 'Error' });
+      showModal(`Failed to open diagnostics folder: ${e}`, { title: 'Error' });
     }
   });
 


### PR DESCRIPTION
## Summary

The "View Last Sent Data" button (App Settings > Privacy & Telemetry) called `collect_hardware_info` and pretty-printed the whole payload into the generic `showModal()` dialog, which isn't sized for a multi-KB JSON dump, it renders as a way-too-big frame.

Since the settings/telemetry storage change, `settings.json`, `telemetry.json`, and `last_hardware_ping.json` all live together in one per-user AppData folder. Rather than reformatting the JSON dump to fit a nicer modal, it's more useful to just open that folder directly so the user can inspect the real files in their own file manager (and see all three files, not just the hardware ping payload).

## Changes

- Added `open_diagnostics_folder` (`src-tauri/src/telemetry.rs`), which resolves `user_data_dir()` and reuses the existing `open_in_explorer` command.
- Rewired the button's click handler to call it instead of `collect_hardware_info` + `showModal`.
- Relabeled the button "Open Diagnostics Folder" to match the new behavior.

## Test plan

- [x] `cargo check` passes clean
- [x] Ran the app, clicked the button, and confirmed it opens Explorer directly at `%APPDATA%\com.actions-and-stuff.rtx-patcher\` instead of showing a modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)